### PR TITLE
fix: Event listener cleanup and update validation

### DIFF
--- a/src/services/bookmarks.service.js
+++ b/src/services/bookmarks.service.js
@@ -70,7 +70,7 @@ export class BookmarksService {
    * @param {string} id - Bookmark ID
    * @param {Object} updates - Fields to update
    * @returns {Promise<Object>} Updated bookmark object
-   * @throws {Error} If update fails
+   * @throws {Error} If update fails or bookmark not found
    */
   async update(id, updates) {
     const { data, error } = await this.#supabase
@@ -81,6 +81,10 @@ export class BookmarksService {
 
     if (error) {
       throw error;
+    }
+
+    if (!data || data.length === 0) {
+      throw new Error(`Bookmark with id ${id} not found`);
     }
 
     return data[0];

--- a/tests/unit/bookmarks.service.test.js
+++ b/tests/unit/bookmarks.service.test.js
@@ -166,6 +166,17 @@ describe("BookmarksService", () => {
         "Update failed",
       );
     });
+
+    it("should throw error if bookmark not found", async () => {
+      mockSupabase.select.mockResolvedValue({
+        data: [],
+        error: null,
+      });
+
+      await expect(bookmarksService.update("999", {})).rejects.toThrow(
+        "Bookmark with id 999 not found",
+      );
+    });
   });
 
   describe("delete", () => {


### PR DESCRIPTION
Add disconnectedCallback to linkstack-bookmarks to prevent memory leaks:
- Store bound event handlers for proper cleanup when component is removed
- Remove window event listeners in disconnectedCallback
- Prevents duplicate listeners when component reconnects to DOM

Add validation to BookmarksService.update():
- Throw error when bookmark ID not found instead of returning undefined
- Provide descriptive error message with bookmark ID
- Update JSDoc to document the new error case
- Add test coverage for validation failure scenario

Fixes two post-merge issues:
1. Window event listeners accumulating on component reconnection
2. Update method silently succeeding for non-existent bookmarks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves component lifecycle handling and strengthens update semantics.
> 
> - Add `disconnectedCallback` to `linkstack-bookmarks-supabase.js`, store bound handlers, and remove `window` listeners to prevent duplicate listeners/memory leaks
> - Refine `BookmarksService.update` to throw when no rows are updated (bookmark not found) and update JSDoc
> - Add unit test for the not-found update case in `tests/unit/bookmarks.service.test.js`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95492c40b319a08b147e52003d66cc08b170a1ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->