### PR TITLE
feat: Add form drawer popover for creating bookmarks (Phase 2)

### DIFF
--- a/css/components/form-drawer.css
+++ b/css/components/form-drawer.css
@@ -1,0 +1,170 @@
+/* Form Drawer - Side panel for adding bookmarks */
+
+.form-drawer {
+  /* Positioning - inline-end side drawer */
+  background: var(--bg-primary, #fff);
+  block-size: 100vh;
+  border: none;
+  border-inline-start: 0.0625rem solid var(--border-color, #e0e0e0);
+  box-shadow: -0.25rem 0 1.5rem rgb(0 0 0 / 10%);
+  display: flex;
+  flex-direction: column;
+  inline-size: 95vw;
+  inset: unset;
+  inset-block-start: 0;
+  inset-inline-end: 0;
+  margin: 0;
+  max-inline-size: 37.5rem;
+  opacity: 0;
+  overflow: hidden;
+  padding: 0;
+  position: fixed;
+
+  /* Animation */
+  transform: translateX(100%);
+  transition:
+    opacity 0.3s ease,
+    transform 0.3s ease,
+    overlay 0.3s allow-discrete,
+    display 0.3s allow-discrete;
+}
+
+/* When popover is open */
+.form-drawer:popover-open {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+/* Entry animation */
+@starting-style {
+  .form-drawer:popover-open {
+    opacity: 0;
+    transform: translateX(100%);
+  }
+}
+
+/* Header */
+.form-drawer-header {
+  align-items: center;
+  background: var(--bg-primary, #fff);
+  border-block-end: 0.0625rem solid var(--border-color, #e0e0e0);
+  display: flex;
+  inset-block-start: 0;
+  justify-content: space-between;
+  padding: 1.5rem;
+  position: sticky;
+  z-index: 10;
+}
+
+.form-drawer-header h2 {
+  color: var(--text-primary, #000);
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+/* Close button */
+.form-drawer-close {
+  align-items: center;
+  background: none;
+  border: none;
+  border-radius: 0.25rem;
+  color: var(--text-secondary, #666);
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  margin: -0.5rem;
+  padding: 0.5rem;
+  transition: all 0.2s ease;
+}
+
+.form-drawer-close:hover {
+  background: var(--bg-secondary, #f5f5f5);
+  color: var(--text-primary, #000);
+}
+
+.form-drawer-close:focus {
+  outline: 0.125rem solid var(--focus-color, #007bff);
+  outline-offset: 0.125rem;
+}
+
+/* Content */
+.form-drawer-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.5rem;
+}
+
+/* Form inside drawer */
+.form-drawer-content .linkstack-form {
+  flex-direction: column;
+  max-inline-size: none;
+}
+
+.form-drawer-content .form-field {
+  flex: initial;
+  inline-size: 100%;
+}
+
+.form-drawer-content .form-field-collapsible {
+  flex: initial;
+  inline-size: 100%;
+}
+
+/* Make collapsible field expand naturally in drawer - revert to default details behavior */
+.form-drawer-content .form-field-collapsible[open] {
+  block-size: auto;
+}
+
+.form-drawer-content .linkstack-form input,
+.form-drawer-content .linkstack-form select,
+.form-drawer-content .linkstack-form textarea {
+  inline-size: 100%;
+}
+
+.form-drawer-content .linkstack-form button[type="submit"] {
+  inline-size: 100%;
+  margin-block-start: 0.5rem;
+}
+
+/* New Bookmark Button */
+.new-bookmark-btn {
+  align-items: center;
+  display: flex;
+  font-size: 0.875rem;
+  gap: 0.5rem;
+  margin-inline-end: 1rem;
+  padding: 0.625rem 1rem;
+}
+
+.new-bookmark-btn svg {
+  flex-shrink: 0;
+}
+
+/* Responsive */
+@media (width <= 48rem) {
+  .form-drawer {
+    inline-size: 100vw;
+    max-inline-size: 100vw;
+  }
+
+  .new-bookmark-btn span {
+    display: none;
+  }
+
+  .new-bookmark-btn {
+    padding: 0.625rem;
+  }
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .form-drawer {
+    animation: none;
+    transition: none;
+  }
+
+  .form-drawer:popover-open {
+    transform: translateX(0);
+  }
+}

--- a/css/components/linkstack-form.css
+++ b/css/components/linkstack-form.css
@@ -52,22 +52,13 @@
 .form-field-collapsible[open] {
   &::details-content {
     background-color: var(--bg-primary, #fff);
-    border: var(--minimalist-input-border, var(--border-primary-border));
     border-block-start: 0;
     inline-size: 100%;
-    inset-block-start: 100%;
-    inset-inline-start: -0.125rem;
-    position: absolute;
-    z-index: 10;
   }
 
   .form-field-summary::before {
     transform: rotate(90deg);
   }
-}
-
-.form-field-summary:hover {
-  background: var(--bg-secondary, #f9f9f9);
 }
 
 .form-field-summary:focus-visible {

--- a/index.html
+++ b/index.html
@@ -88,6 +88,12 @@
       href="css/components/app-header.css"
       media="screen"
     />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="css/components/form-drawer.css"
+      media="screen"
+    />
     <style>
       .hidden {
         display: none;
@@ -153,16 +159,43 @@
           <h1 class="logo-text">LinkStack</h1>
         </div>
         <nav class="header-nav">
+          <button
+            type="button"
+            class="button solid new-bookmark-btn"
+            id="new-bookmark-btn"
+            popovertarget="form-drawer"
+            aria-label="Add new bookmark"
+            title="Add new bookmark (Ctrl+N)"
+          >
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+              <path d="M8 2a.5.5 0 0 1 .5.5v5h5a.5.5 0 0 1 0 1h-5v5a.5.5 0 0 1-1 0v-5h-5a.5.5 0 0 1 0-1h5v-5A.5.5 0 0 1 8 2Z"/>
+            </svg>
+            <span>New Bookmark</span>
+          </button>
           <div id="header-profile"></div>
         </nav>
       </div>
     </header>
 
-    <!-- Main Content (hidden until authenticated) -->
-    <div class="page-container main-content hidden">
-      <h1 class="heading-display page-heading">LinkStack</h1>
-
-      <linkstack-form>
+    <!-- Form Drawer Popover (hidden until authenticated) -->
+    <form-drawer class="form-drawer hidden" id="form-drawer" popover anchor="new-bookmark-btn">
+      <div class="form-drawer-header">
+        <h2 id="form-drawer-title">Add New Bookmark</h2>
+        <button
+          type="button"
+          class="form-drawer-close"
+          id="form-drawer-close"
+          aria-label="Close"
+          popovertarget="form-drawer"
+          popovertargetaction="hide"
+        >
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <path d="M18 6L6 18M6 6l12 12"/>
+          </svg>
+        </button>
+      </div>
+      <div class="form-drawer-content">
+        <linkstack-form>
         <form
           class="linkstack-form"
           id="bookmark-form"
@@ -182,10 +215,10 @@
           </div>
           <div class="form-field">
             <label class="visually-hidden" for="parent-bookmark"
-              >Add as child of (optional)</label
+              >Add to stack (optional)</label
             >
             <select name="parent_id" id="parent-bookmark">
-              <option value="">Add as child of (optional)</option>
+              <option value="">Add to stack (optional)</option>
             </select>
           </div>
           <details class="form-field-collapsible">
@@ -206,6 +239,12 @@
           </button>
         </form>
       </linkstack-form>
+      </div>
+    </form-drawer>
+
+    <!-- Main Content (hidden until authenticated) -->
+    <div class="page-container main-content hidden">
+      <h1 class="heading-display page-heading visually-hidden">LinkStack</h1>
 
       <!-- Search Bar -->
       <div class="search-bar-container" role="search">

--- a/src/app.js
+++ b/src/app.js
@@ -4,6 +4,7 @@ import "./linkstack-auth.js";
 import "./linkstack-form-supabase.js";
 import "./linkstack-bookmarks-supabase.js";
 import "./linkstack-edit-dialog-supabase.js";
+import "./form-drawer.js";
 
 /**
  * Main application coordinator
@@ -79,14 +80,18 @@ class LinkStackApp {
   }
 
   #handleAuthChange(user) {
+    const formDrawer = document.getElementById("form-drawer");
+
     if (user) {
       // User is signed in
       this.#authComponent?.setUser(user);
       this.#mainContent?.classList.remove("hidden");
+      formDrawer?.classList.remove("hidden");
     } else {
       // User is signed out
       this.#authComponent?.setUser(null);
       this.#mainContent?.classList.add("hidden");
+      formDrawer?.classList.add("hidden");
     }
   }
 }

--- a/src/form-drawer.js
+++ b/src/form-drawer.js
@@ -1,0 +1,59 @@
+/**
+ * Form Drawer Web Component
+ * Manages opening/closing the bookmark form popover with keyboard shortcuts
+ */
+class FormDrawer extends HTMLElement {
+  constructor() {
+    super();
+  }
+
+  connectedCallback() {
+    this.#attachEventListeners();
+  }
+
+  #attachEventListeners() {
+    // Keyboard shortcut: Ctrl+N or Cmd+N
+    document.addEventListener("keydown", (e) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === "n") {
+        e.preventDefault();
+        this.open();
+      }
+    });
+
+    // Close on successful bookmark creation
+    window.addEventListener("bookmark-created", () => {
+      this.close();
+    });
+
+    // Focus URL input when popover opens
+    this.addEventListener("toggle", (e) => {
+      if (e.newState === "open") {
+        const urlInput = this.querySelector("#url");
+        if (urlInput) {
+          // Small delay to ensure popover animation has started
+          setTimeout(() => {
+            urlInput.focus();
+          }, 100);
+        }
+      }
+    });
+  }
+
+  /**
+   * Open the form drawer
+   */
+  open() {
+    this.showPopover();
+  }
+
+  /**
+   * Close the form drawer
+   */
+  close() {
+    this.hidePopover();
+  }
+}
+
+customElements.define("form-drawer", FormDrawer);
+
+export { FormDrawer };


### PR DESCRIPTION
## Summary

Implements Phase 2 of the UI redesign by replacing the inline form with a slide-in drawer popover for creating bookmarks.

### Key Features

- **Slide-in Drawer**: Form appears as a popover that slides in from the right side
- **Keyboard Shortcut**: Press `Ctrl+N` (Windows/Linux) or `Cmd+N` (Mac) to open drawer
- **Web Component**: `FormDrawer` extends `HTMLElement` following existing component patterns
- **Auto-focus**: URL input automatically receives focus when drawer opens
- **Auto-close**: Drawer closes automatically after successful bookmark creation
- **Authentication Gating**: Drawer is hidden until user is authenticated

### Layout Improvements

- Vertical form layout with stacked fields (better for narrow drawer)
- Full-width inputs and submit button
- Collapsible notes section with natural document flow
- Removed absolute positioning from `::details-content`

### Design Details

- Smooth slide-in animation from right edge
- Sticky header with close button
- Scrollable content area
- Responsive: full-width on mobile devices
- Respects `prefers-reduced-motion`
- Uses logical properties and relative units throughout

### Terminology Updates

- Changed "Add as child of" to "Add to stack" (aligning with stacks terminology)

### Technical Implementation

- Uses Popover API for non-modal overlay behavior
- Custom element registered as `<form-drawer>`
- Integrated with existing authentication flow in `app.js`
- New stylesheet: `css/components/form-drawer.css`
- "New Bookmark" button added to header with `popovertarget` attribute

### Files Changed

- **Created**: `src/form-drawer.js` - Web component controller
- **Created**: `css/components/form-drawer.css` - Drawer styles
- **Modified**: `index.html` - Added drawer markup and button
- **Modified**: `src/app.js` - Authentication state management
- **Modified**: `css/components/linkstack-form.css` - Removed absolute positioning

### Testing Checklist

- [ ] Drawer opens with "New Bookmark" button click
- [ ] Drawer opens with `Ctrl+N` / `Cmd+N` keyboard shortcut
- [ ] URL input receives focus when drawer opens
- [ ] Drawer closes after successful bookmark creation
- [ ] Drawer is hidden before authentication
- [ ] Drawer appears after successful login
- [ ] Collapsible notes section expands naturally
- [ ] Form submission works correctly
- [ ] Responsive layout on mobile devices
- [ ] Animation respects reduced motion preferences

🤖 Generated with [Claude Code](https://claude.com/claude-code)