### PR TITLE
feat: Add app state manager for conditional component loading

### DIFF
--- a/src/linkstack-bookmarks-supabase.js
+++ b/src/linkstack-bookmarks-supabase.js
@@ -126,11 +126,8 @@ export class LinkStackBookmarks extends HTMLElement {
     this.#setupSort();
     this.#setupFilter();
 
-    // Only render if the main content is visible (user is authenticated)
-    const mainContent = document.querySelector(".main-content");
-    if (mainContent && !mainContent.classList.contains("hidden")) {
-      await this.#renderBookmarks();
-    }
+    // Component is only loaded when authenticated, safe to render
+    await this.#renderBookmarks();
   }
 
   #addEventListeners() {

--- a/src/state/app-state.js
+++ b/src/state/app-state.js
@@ -1,0 +1,91 @@
+/**
+ * Simple app state manager
+ * Manages application state and component lifecycle based on auth status
+ */
+
+const AppState = {
+  UNAUTHENTICATED: "unauthenticated",
+  AUTHENTICATED: "authenticated",
+};
+
+class AppStateManager {
+  #currentState = AppState.UNAUTHENTICATED;
+  #listeners = new Set();
+  #componentsInitialized = false;
+
+  constructor() {
+    // Singleton pattern
+    if (AppStateManager.instance) {
+      return AppStateManager.instance;
+    }
+    AppStateManager.instance = this;
+  }
+
+  /**
+   * Get current app state
+   */
+  get state() {
+    return this.#currentState;
+  }
+
+  /**
+   * Check if user is authenticated
+   */
+  get isAuthenticated() {
+    return this.#currentState === AppState.AUTHENTICATED;
+  }
+
+  /**
+   * Check if components have been initialized
+   */
+  get componentsInitialized() {
+    return this.#componentsInitialized;
+  }
+
+  /**
+   * Set app state
+   * @param {string} newState - New state (AppState.AUTHENTICATED or AppState.UNAUTHENTICATED)
+   */
+  setState(newState) {
+    if (this.#currentState === newState) {
+      return;
+    }
+
+    const previousState = this.#currentState;
+    this.#currentState = newState;
+
+    // Notify all listeners
+    this.#listeners.forEach((listener) => {
+      listener(newState, previousState);
+    });
+  }
+
+  /**
+   * Subscribe to state changes
+   * @param {Function} listener - Callback function (newState, previousState) => void
+   * @returns {Function} Unsubscribe function
+   */
+  subscribe(listener) {
+    this.#listeners.add(listener);
+    return () => this.#listeners.delete(listener);
+  }
+
+  /**
+   * Mark components as initialized
+   */
+  markComponentsInitialized() {
+    this.#componentsInitialized = true;
+  }
+
+  /**
+   * Reset components initialized flag
+   */
+  resetComponentsInitialized() {
+    this.#componentsInitialized = false;
+  }
+}
+
+// Export singleton instance
+const appStateManager = new AppStateManager();
+
+export { appStateManager, AppState };


### PR DESCRIPTION
- Create AppStateManager singleton to manage auth state
- Dynamically import authenticated components only when needed
- Components (form, bookmarks, edit-dialog) load on-demand after sign-in
- Prevents components from mounting and making API calls before auth
- Eliminates "Failed to fetch" errors on unauthenticated page load

Architecture:
- State manager tracks AUTHENTICATED/UNAUTHENTICATED states
- app.js subscribes to state changes
- Authenticated components lazy-loaded via dynamic imports
- Components only execute when user is authenticated

Fixes production deployment errors with clean state separation