### PR TITLE
fix: prevent horizontal overflow and improve responsive layout

### DIFF
--- a/public/css/components/app-header.css
+++ b/public/css/components/app-header.css
@@ -11,13 +11,19 @@
 }
 
 .header-container {
-  max-width: 1200px;
+  max-width: min(1200px, 100%);
   margin: 0 auto;
-  padding: 0.75rem 2rem;
+  padding: 0.75rem 1.5rem;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 1.5rem;
+  gap: 1rem;
+}
+
+@media (width >= 48rem) {
+  .header-container {
+    padding-inline: 2rem;
+  }
 }
 
 /* Logo */
@@ -206,13 +212,17 @@
 }
 
 /* Responsive */
-@media (max-width: 768px) {
+@media (width <= 48rem) {
   .header-container {
     padding: 0.625rem 1rem;
   }
 
   .logo-text {
     font-size: 1.125rem;
+  }
+
+  .new-bookmark-btn span {
+    display: none;
   }
 
   .profile-name {

--- a/public/css/linkstack.css
+++ b/public/css/linkstack.css
@@ -38,8 +38,14 @@ body {
 
 .page-container {
   margin: 0 auto;
-  max-inline-size: 1200px;
-  padding-inline: 2rem;
+  max-inline-size: min(1200px, 100%);
+  padding-inline: 1.5rem;
+}
+
+@media (width >= 48rem) {
+  .page-container {
+    padding-inline: 2rem;
+  }
 }
 
 .page-heading {

--- a/src/components/view-toggle.js
+++ b/src/components/view-toggle.js
@@ -20,6 +20,7 @@ class ViewToggle extends HTMLElement {
     this.#buttons = this.querySelectorAll(ViewToggle.#selectors.button);
     this.#loadViewPreference();
     this.#attachEventListeners();
+    this.#updateButtons();
     this.#applyView();
   }
 


### PR DESCRIPTION
## Summary
- Page container and header used fixed `max-width: 1200px` without viewport constraint, causing horizontal scroll on narrower viewports
- Changed to `min(1200px, 100%)` so content never exceeds viewport width
- Reduced base padding to `1.5rem`, scaling to `2rem` at `>=48rem`
- Hidden "New" button label text at `<=48rem` (icon remains)
- Fixed view-toggle button state not syncing on init when localStorage preference differs from HTML default

## Test plan
- [ ] No horizontal scrollbar at any viewport width (test 320px through 1440px+)
- [ ] Grid switches from 1 → 2 → 3 columns at correct breakpoints
- [ ] Header doesn't clip profile name/button at ~1200px viewport
- [ ] View toggle button state matches actual view on page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)