### PR TITLE
fix: use Popover API with CSS anchor positioning for context menus

### DIFF
--- a/public/css/components/context-menu.css
+++ b/public/css/components/context-menu.css
@@ -32,11 +32,16 @@
   box-shadow: var(--ls-shadow-lg);
   display: flex;
   flex-direction: column;
+  inset: unset;
   margin: 0;
   min-inline-size: 10rem;
   opacity: 0;
   padding: 0.25rem;
   position: fixed;
+  position-anchor: implicit;
+  inset-block-start: anchor(end);
+  inset-inline-end: anchor(end);
+  position-try-fallbacks: flip-block, flip-inline;
   transform: scale(0.95);
   transition:
     opacity 0.12s ease,

--- a/src/linkstack-bookmarks-supabase.js
+++ b/src/linkstack-bookmarks-supabase.js
@@ -180,13 +180,9 @@ export class LinkStackBookmarks extends HTMLElement {
         return;
       }
 
-      // Handle context menu trigger click
+      // Context menu trigger click is handled by popovertarget attribute
       const contextMenuTrigger = event.target.closest(".context-menu-trigger");
       if (contextMenuTrigger) {
-        const contextMenu = contextMenuTrigger.nextElementSibling;
-        if (contextMenu && contextMenu.hasAttribute("popover")) {
-          contextMenu.togglePopover();
-        }
         return;
       }
 
@@ -821,6 +817,13 @@ export class LinkStackBookmarks extends HTMLElement {
           deleteBookmark.dataset.id = bookmark.id;
           editBookmark.dataset.id = bookmark.id;
 
+          // Wire up popovertarget for context menu anchor positioning
+          const contextMenuTrigger = entry.querySelector(".context-menu-trigger");
+          const contextMenu = entry.querySelector(".context-menu");
+          const contextMenuId = `context-menu-${bookmark.id}`;
+          contextMenu.id = contextMenuId;
+          contextMenuTrigger.setAttribute("popovertarget", contextMenuId);
+
           // Setup read/unread toggle
           const readToggle = entry.querySelector("#toggle-read-status");
           readToggle.dataset.id = bookmark.id;
@@ -888,6 +891,13 @@ export class LinkStackBookmarks extends HTMLElement {
 
               childDelete.dataset.id = child.id;
               childEdit.dataset.id = child.id;
+
+              // Wire up popovertarget for context menu anchor positioning
+              const childContextTrigger = childEntry.querySelector(".context-menu-trigger");
+              const childContextMenu = childEntry.querySelector(".context-menu");
+              const childContextMenuId = `context-menu-${child.id}`;
+              childContextMenu.id = childContextMenuId;
+              childContextTrigger.setAttribute("popovertarget", childContextMenuId);
 
               // Setup read/unread toggle for child
               const childReadToggle = childEntry.querySelector(


### PR DESCRIPTION
## Summary
- Context menu popover was rendering at the top-left of the viewport because it had no positioning relationship with its trigger button
- Added `popovertarget` attribute on each trigger button pointing to a unique context menu ID, creating an implicit anchor
- Used CSS anchor positioning (`top: anchor(bottom)`, `right: anchor(right)`) to place the menu below and aligned to the trigger
- Added `position-try-fallbacks: flip-block, flip-inline` so the menu flips when it would overflow the viewport
- Removed the manual JS `togglePopover()` call since `popovertarget` handles toggling natively

## Test plan
- [ ] Click three-dot menu on any bookmark card — menu appears anchored to the trigger
- [ ] Scroll to bottom of page, click a menu — should flip above if no space below
- [ ] Click a menu on a right-edge card — should flip left if needed
- [ ] "Edit Bookmark" and "Remove Bookmark" actions still work
- [ ] Menu dismisses on outside click or pressing Escape

🤖 Generated with [Claude Code](https://claude.com/claude-code)