### PR TITLE
fix: make edit dialog fill viewport on mobile

### DIFF
--- a/public/css/components/linkstack-dialog.css
+++ b/public/css/components/linkstack-dialog.css
@@ -23,6 +23,15 @@
 
 @media (width <= 48rem) {
   .linkstack-dialog {
-    inline-size: 90vw;
+    block-size: 100vh;
+    block-size: 100dvh;
+    border: none;
+    border-radius: 0;
+    inline-size: 100vw;
+    margin: 0;
+    max-block-size: 100vh;
+    max-block-size: 100dvh;
+    max-inline-size: 100vw;
+    overflow-y: auto;
   }
 }


### PR DESCRIPTION
## Summary
- On mobile (`<= 48rem`), the edit bookmark dialog now fills the entire viewport
- Removes border-radius and border for a clean fullscreen appearance
- Uses `100dvh` with `100vh` fallback for proper height on mobile browsers
- Enables `overflow-y: auto` so content remains scrollable

## Test plan
- [ ] Open edit dialog on mobile — fills entire screen edge to edge
- [ ] Dialog content scrolls if it exceeds viewport height
- [ ] Close button and form actions remain accessible
- [ ] On desktop (> 48rem), dialog retains its centered card appearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)