### PR TITLE
Preserve signed-in state when admin lookup fails

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -120,7 +120,7 @@ class LinkStackApp {
 
     this.#authService.onAuthStateChange(async (event, session) => {
       const user = session?.user ?? null;
-      const isAdmin = user ? await this.#authService.isAdmin() : false;
+      const isAdmin = await this.#resolveAdminState(user, "auth-state-change");
       await this.#handleAuthChange(user, isAdmin);
     });
 
@@ -151,7 +151,7 @@ class LinkStackApp {
   async #checkAuthState() {
     try {
       const user = await this.#authService.getCurrentUser();
-      const isAdmin = user ? await this.#authService.isAdmin() : false;
+      const isAdmin = await this.#resolveAdminState(user, "check-auth-state");
       await this.#handleAuthChange(user, isAdmin);
     } catch (error) {
       captureException(error, {
@@ -159,6 +159,25 @@ class LinkStackApp {
         action: "check-auth-state",
       });
       await this.#handleAuthChange(null, false);
+    }
+  }
+
+  async #resolveAdminState(user, action) {
+    if (!user) {
+      return false;
+    }
+
+    try {
+      return await this.#authService.isAdmin();
+    } catch (error) {
+      captureException(error, {
+        surface: "app",
+        action,
+        authState: "admin-check",
+        userId: user.id,
+      });
+
+      return false;
     }
   }
 


### PR DESCRIPTION
## Summary
- keep the authenticated shell active even if the admin role lookup fails
- treat admin resolution as optional metadata instead of part of session validity
- capture the admin lookup failure for monitoring while falling back to non-admin behavior

## Testing
- npm run lint:js
- npm run typecheck

## Notes
- I attempted 
> linkstack@1.0.0 build
> vite build

vite v7.3.1 building client environment for production...
transforming...
✓ 338 modules transformed.
rendering chunks...
computing gzip size...
[vite-plugin-static-copy] Copied 7 items.
dist/index.html                                          29.79 kB │ gzip:  4.84 kB
dist/assets/form-drawer-BtOyVjW7.js                       1.28 kB │ gzip:  0.57 kB
dist/assets/linkstack-edit-dialog-supabase-C8fPG2-u.js    3.49 kB │ gzip:  1.29 kB
dist/assets/linkstack-public-reviews-Dk5hmslZ.js          5.64 kB │ gzip:  2.01 kB
dist/assets/linkstack-form-supabase-qGS51Gr8.js           6.17 kB │ gzip:  2.53 kB
dist/assets/main-DI0bihc5.js                            315.42 kB │ gzip: 90.06 kB
✓ built in 773ms, but it hung in this environment rather than returning a code error, so I did not block this focused auth-state fix on that.