### PR TITLE
Fix recursive admin role checks

### DIFF
--- a/supabase/migrations/20260315_fix_user_roles_rls_recursion.sql
+++ b/supabase/migrations/20260315_fix_user_roles_rls_recursion.sql
@@ -1,0 +1,24 @@
+-- Migration: fix recursive RLS checks on public.user_roles
+-- Date: 2026-03-15
+-- Description:
+--   The original is_admin() helper queried public.user_roles while RLS policies on
+--   public.user_roles also called is_admin(). That caused recursive policy evaluation
+--   and "stack depth limit exceeded" errors during admin checks.
+--
+--   This migration makes is_admin() SECURITY DEFINER so it can evaluate against
+--   public.user_roles without re-entering the same RLS policies.
+
+CREATE OR REPLACE FUNCTION public.is_admin(check_user_id UUID DEFAULT auth.uid())
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.user_roles
+    WHERE user_id = check_user_id
+      AND role = 'admin'
+  );
+$$;

--- a/supabase/migrations/README.md
+++ b/supabase/migrations/README.md
@@ -26,6 +26,12 @@ If you already have a LinkStack database running and need to add new features, r
 - Creates index for efficient parent-child queries
 - Safe to run multiple times (uses `IF NOT EXISTS`)
 
+**`20260315_fix_user_roles_rls_recursion.sql`**
+
+- Fixes recursive RLS evaluation on `public.user_roles`
+- Updates `public.is_admin()` to run as `SECURITY DEFINER`
+- Resolves `stack depth limit exceeded` errors during admin checks
+
 ### How to Run Migrations
 
 1. Open your Supabase project dashboard

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -60,6 +60,8 @@ CREATE OR REPLACE FUNCTION public.is_admin(check_user_id UUID DEFAULT auth.uid()
 RETURNS BOOLEAN
 LANGUAGE sql
 STABLE
+SECURITY DEFINER
+SET search_path = public
 AS $$
   SELECT EXISTS (
     SELECT 1


### PR DESCRIPTION
## Summary
- fix recursive RLS evaluation on public.user_roles
- update public.is_admin() to run as SECURITY DEFINER so admin checks do not recurse through the same policies
- add a migration for existing Supabase projects and document it in the migrations README

## Notes
- apply supabase/migrations/20260315_fix_user_roles_rls_recursion.sql in the live Supabase project to stop the current production errors immediately
