### PR TITLE
Make Supabase auth persistence explicit

### DIFF
--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -4,11 +4,21 @@ import { ENV } from "varlock/env";
 
 const supabaseUrl = ENV.VITE_SUPABASE_URL;
 const supabaseAnonKey = ENV.VITE_SUPABASE_ANON_KEY;
+const isBrowser = typeof window !== "undefined";
+const authStorage = isBrowser ? window.localStorage : undefined;
 
 if (!supabaseUrl || !supabaseAnonKey) {
   throw new Error(
-    "Missing Supabase environment variables. Please check your .env file.",
+    "Missing Supabase environment variables. Please check your environment configuration.",
   );
 }
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+  auth: {
+    autoRefreshToken: true,
+    detectSessionInUrl: true,
+    persistSession: true,
+    storage: authStorage,
+    storageKey: "linkstack-auth",
+  },
+});


### PR DESCRIPTION
## Summary
- configure the browser Supabase client with explicit auth persistence settings
- use a stable storage key for persisted auth state
- make session detection and refresh behavior explicit instead of relying on library defaults

## Testing
- npm run lint:js
- npm run typecheck
- npm run build