### PR TITLE
Avoid nested auth work during auth state changes

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -118,10 +118,14 @@ class LinkStackApp {
       }
     });
 
-    this.#authService.onAuthStateChange(async (event, session) => {
+    this.#authService.onAuthStateChange((event, session) => {
       const user = session?.user ?? null;
-      const isAdmin = await this.#resolveAdminState(user, "auth-state-change");
-      await this.#handleAuthChange(user, isAdmin);
+
+      // Avoid nested auth work inside Supabase's auth callback. Defer the
+      // follow-up role lookup and UI sync to the next task.
+      setTimeout(() => {
+        void this.#syncAuthState(user, "auth-state-change");
+      }, 0);
     });
 
     this.#scopeSelect?.addEventListener("change", async () => {
@@ -151,8 +155,7 @@ class LinkStackApp {
   async #checkAuthState() {
     try {
       const user = await this.#authService.getCurrentUser();
-      const isAdmin = await this.#resolveAdminState(user, "check-auth-state");
-      await this.#handleAuthChange(user, isAdmin);
+      await this.#syncAuthState(user, "check-auth-state");
     } catch (error) {
       captureException(error, {
         surface: "app",
@@ -162,13 +165,18 @@ class LinkStackApp {
     }
   }
 
+  async #syncAuthState(user, action) {
+    const isAdmin = await this.#resolveAdminState(user, action);
+    await this.#handleAuthChange(user, isAdmin);
+  }
+
   async #resolveAdminState(user, action) {
     if (!user) {
       return false;
     }
 
     try {
-      return await this.#authService.isAdmin();
+      return await this.#authService.isAdmin(user.id);
     } catch (error) {
       captureException(error, {
         surface: "app",

--- a/src/services/auth.service.js
+++ b/src/services/auth.service.js
@@ -91,19 +91,20 @@ export class AuthService {
 
   /**
    * Check whether the current user has the admin role.
+   * @param {string | null} [userId]
    * @returns {Promise<boolean>}
    */
-  async isAdmin() {
-    const user = await this.getCurrentUser();
+  async isAdmin(userId = null) {
+    const targetUserId = userId ?? (await this.getCurrentUser())?.id ?? null;
 
-    if (!user) {
+    if (!targetUserId) {
       return false;
     }
 
     const { data, error } = await this.#supabase
       .from("user_roles")
       .select("role")
-      .eq("user_id", user.id)
+      .eq("user_id", targetUserId)
       .eq("role", "admin")
       .maybeSingle();
 

--- a/tests/unit/auth.service.test.js
+++ b/tests/unit/auth.service.test.js
@@ -76,6 +76,16 @@ describe("AuthService", () => {
   });
 
   it("returns true for isAdmin when the admin role exists", async () => {
+    mockSupabase.maybeSingle.mockResolvedValue({
+      data: { role: "admin" },
+      error: null,
+    });
+
+    await expect(authService.isAdmin("user-1")).resolves.toBe(true);
+    expect(mockSupabase.from).toHaveBeenCalledWith("user_roles");
+  });
+
+  it("uses the current session user id when isAdmin is called without an argument", async () => {
     mockSupabase.auth.getSession.mockResolvedValue({
       data: { session: { user: { id: "user-1" } } },
       error: null,
@@ -86,6 +96,6 @@ describe("AuthService", () => {
     });
 
     await expect(authService.isAdmin()).resolves.toBe(true);
-    expect(mockSupabase.from).toHaveBeenCalledWith("user_roles");
+    expect(mockSupabase.eq).toHaveBeenCalledWith("user_id", "user-1");
   });
 });


### PR DESCRIPTION
## Summary
- avoid nested auth work inside Supabase auth state callbacks
- defer the app-level auth sync work to the next task instead of running it inline
- allow admin checks to use a known user id so the callback does not re-enter auth session reads

## Testing
- npm test -- --run tests/unit/auth.service.test.js
- npm run lint:js
- npm run typecheck
- npm run build