### PR TITLE
Fix public submission flow and metadata fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -232,14 +232,21 @@
               ></textarea>
             </div>
           </details>
-          <div class="form-field">
-            <label class="limit-toggle" for="request-public">
-              <input type="checkbox" name="request_public" id="request-public" />
-              <span class="limit-label">Submit to the public catalog</span>
+          <div class="form-field public-submit-field">
+            <label class="public-submit-toggle" for="request-public">
+              <input
+                class="public-submit-checkbox"
+                type="checkbox"
+                name="request_public"
+                id="request-public"
+              />
+              <span class="public-submit-copy">
+                <span class="public-submit-label">Submit to the public catalog</span>
+                <span class="public-submit-help" id="request-public-help">
+                  Public submissions remain private in your library and require moderator approval before they appear publicly.
+                </span>
+              </span>
             </label>
-            <p class="tags-hint" id="request-public-help">
-              Public submissions remain private in your library and require moderator approval before they appear publicly.
-            </p>
           </div>
           <button class="button solid" type="submit" id="submit-bookmark">
             <span class="button-text">Add Bookmark</span>

--- a/netlify/functions/get-bookmark-data/get-bookmark-data.js
+++ b/netlify/functions/get-bookmark-data/get-bookmark-data.js
@@ -14,6 +14,8 @@ const JSON_HEADERS = {
   "content-type": "application/json",
 };
 
+const UPSTREAM_TIMEOUT_MS = 8000;
+
 const REQUEST_HEADERS = Object.freeze({
   "User-Agent":
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
@@ -34,7 +36,7 @@ const getAllowedOrigin = (requestOrigin) => {
   const allowedOrigins = [
     "http://localhost:8888",
     "http://localhost:3000",
-    "https://linkstacks.netlify.app", // Add your production domain
+    "https://linkstack.netlify.app",
   ];
 
   return allowedOrigins.includes(requestOrigin)
@@ -59,6 +61,44 @@ const sanitizeMetadata = (input, fallbackTitle) => {
     pageTitle: fallbackTitle,
     metaDescription: "",
   };
+};
+
+const getErrorCode = (error) => {
+  if (
+    error &&
+    typeof error === "object" &&
+    "cause" in error &&
+    error.cause &&
+    typeof error.cause === "object" &&
+    "code" in error.cause
+  ) {
+    return String(error.cause.code);
+  }
+
+  return null;
+};
+
+const fetchBookmarkResponse = async (bookmark) => {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => {
+    controller.abort();
+  }, UPSTREAM_TIMEOUT_MS);
+  const startedAt = Date.now();
+
+  try {
+    const response = await fetch(bookmark, {
+      headers: REQUEST_HEADERS,
+      redirect: "follow",
+      signal: controller.signal,
+    });
+
+    return {
+      response,
+      elapsedMs: Date.now() - startedAt,
+    };
+  } finally {
+    clearTimeout(timeoutId);
+  }
 };
 
 // Docs on request and context https://docs.netlify.com/functions/build/#code-your-function-2
@@ -106,17 +146,61 @@ export default async (request) => {
       );
     }
 
-    const response = await fetch(bookmark, {
-      headers: REQUEST_HEADERS,
-    });
+    let upstream;
 
-    if (!response.ok) {
+    try {
+      upstream = await fetchBookmarkResponse(bookmark);
+    } catch (error) {
+      const code = getErrorCode(error);
+      const isTimeout =
+        error instanceof DOMException && error.name === "AbortError";
+
+      await captureServerException(error, {
+        functionName: "get-bookmark-data",
+        action: "fetch-upstream",
+        requestUrl: request.url,
+        targetUrl: bookmark,
+        method: request.method,
+        timeoutMs: UPSTREAM_TIMEOUT_MS,
+        errorCode: code,
+      });
+
       return createJsonResponse(
         {
-          error: `Failed to fetch URL: ${response.status} ${response.statusText}`,
+          error: isTimeout
+            ? "Timed out while fetching metadata from the target site."
+            : "Failed to fetch metadata from the target site.",
+          detailCode: code,
         },
         corsHeaders,
-        500,
+        isTimeout ? 504 : 502,
+      );
+    }
+
+    const { response, elapsedMs } = upstream;
+
+    if (!response.ok) {
+      await captureServerException(
+        new Error(`Upstream metadata fetch failed with ${response.status}`),
+        {
+          functionName: "get-bookmark-data",
+          action: "upstream-non-ok-response",
+          requestUrl: request.url,
+          targetUrl: bookmark,
+          method: request.method,
+          upstreamStatus: response.status,
+          upstreamStatusText: response.statusText,
+          upstreamUrl: response.url,
+          elapsedMs,
+        },
+      );
+
+      return createJsonResponse(
+        {
+          error: `Failed to fetch metadata from the target site: ${response.status} ${response.statusText}`,
+        },
+        corsHeaders,
+        502,
       );
     }
 

--- a/public/css/components/linkstack-bookmarks.css
+++ b/public/css/components/linkstack-bookmarks.css
@@ -108,6 +108,45 @@
   max-inline-size: unset;
 }
 
+.review-card .bookmark-info {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1rem;
+}
+
+.review-card .bookmark-description:empty,
+.review-card .bookmark-tags:empty {
+  display: none;
+}
+
+.review-domain {
+  margin-block-end: 0;
+}
+
+.review-controls {
+  display: grid;
+  gap: 0.75rem;
+  margin-block-start: 0.25rem;
+}
+
+.review-card .form-field {
+  margin-block-end: 0;
+}
+
+.review-card .review-reason,
+.review-card .review-note {
+  inline-size: 100%;
+}
+
+.review-card .bookmark-actions {
+  justify-content: end;
+}
+
+.review-actions-primary {
+  flex: 0 0 auto;
+  justify-content: end;
+}
+
 /* No bookmarks state */
 .no-bookmarks-wrapper {
   block-size: 50vh;
@@ -152,6 +191,10 @@
 @media (width >= 40rem) {
   #bookmarks-container.view-grid .bookmarks-list {
     grid-template-columns: repeat(2, 1fr);
+  }
+
+  .review-controls {
+    grid-template-columns: minmax(0, 14rem) minmax(0, 1fr);
   }
 }
 
@@ -229,6 +272,18 @@
   #bookmarks-container.view-list .bookmark-entry {
     align-items: stretch;
     flex-direction: column;
+  }
+
+  .review-card .bookmark-actions {
+    justify-content: stretch;
+  }
+
+  .review-actions-primary {
+    flex: 1;
+  }
+
+  .review-actions-primary .button {
+    flex: 1 1 0;
   }
 }
 

--- a/public/css/components/linkstack-form.css
+++ b/public/css/components/linkstack-form.css
@@ -23,7 +23,7 @@
   }
 
   .form-field-collapsible,
-  input,
+  input:not([type="checkbox"]),
   select {
     block-size: 3rem;
   }
@@ -86,6 +86,65 @@
   display: none;
 }
 
+.public-submit-field {
+  margin-block-start: 0.25rem;
+}
+
+.public-submit-toggle {
+  align-items: start;
+  border: 0.0625rem solid var(--minimalist-input-border, var(--border-primary-border));
+  border-radius: var(--radius-md, 0.75rem);
+  cursor: pointer;
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: auto minmax(0, 1fr);
+  padding: 0.875rem 1rem;
+  transition:
+    border-color 0.2s ease,
+    background-color 0.2s ease;
+}
+
+.public-submit-toggle:hover {
+  background-color: var(--ls-surface-subtle);
+  border-color: var(--ls-accent-soft, var(--ls-accent));
+}
+
+.public-submit-toggle:focus-within {
+  border-color: var(--focus-color, #06c);
+  outline: 0.125rem solid color-mix(in srgb, var(--focus-color, #06c) 20%, transparent);
+  outline-offset: 0.125rem;
+}
+
+.public-submit-toggle.is-disabled {
+  cursor: not-allowed;
+  opacity: 0.75;
+}
+
+.public-submit-checkbox {
+  accent-color: var(--ls-accent);
+  block-size: 1.125rem;
+  inline-size: 1.125rem;
+  margin: 0.1875rem 0 0;
+}
+
+.public-submit-copy {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.public-submit-label {
+  color: var(--ls-text-primary);
+  font-size: 0.9375rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.public-submit-help {
+  color: var(--ls-text-secondary);
+  font-size: 0.8125rem;
+  line-height: 1.45;
+}
+
 input.error,
 select.error,
 textarea.error {
@@ -107,4 +166,14 @@ button[aria-busy="true"] {
 
 button[aria-busy="true"]:hover {
   opacity: 0.7;
+}
+
+@media (width <= 40rem) {
+  .public-submit-toggle {
+    padding: 0.75rem 0.875rem;
+  }
+
+  .public-submit-label {
+    font-size: 0.875rem;
+  }
 }

--- a/src/constants/ui-strings.js
+++ b/src/constants/ui-strings.js
@@ -46,7 +46,8 @@ export const FORM_UI_MESSAGES = Object.freeze({
   duplicateUrl: "This URL has already been bookmarked. Please enter a different URL.",
   bookmarkAdded: "Bookmark added successfully!",
   bookmarkAddedWithReview: "Bookmark added and submitted for public review.",
-  metadataUnavailable: "Bookmark saved (metadata unavailable for this site)",
+  bookmarkAddedWithoutMetadata:
+    "Bookmark saved without fetched title or description. You can edit it later.",
   addBookmarkFailed: "Failed to add bookmark. Please try again.",
   duplicatePublicTitle: "Link already public",
   duplicatePublicPrompt: "This link is already public. Add it to your private bookmarks instead?",

--- a/src/linkstack-form-supabase.js
+++ b/src/linkstack-form-supabase.js
@@ -13,6 +13,8 @@ import {
 } from "./utils/validation-schemas.js";
 
 export class LinkStackForm extends HTMLElement {
+  static #metadataTimeoutMs = 4500;
+
   static #selectors = {
     bookmarkForm: "#bookmark-form",
     parentSelect: "#parent-bookmark",
@@ -103,14 +105,16 @@ export class LinkStackForm extends HTMLElement {
       this.querySelector(LinkStackForm.#selectors.requestPublic)
     );
     const helpText = this.querySelector(LinkStackForm.#selectors.requestPublicHelp);
+    const publicToggleLabel = requestPublic?.closest(".public-submit-toggle");
 
-    if (!parentSelect || !requestPublic || !helpText) {
+    if (!parentSelect || !requestPublic || !helpText || !publicToggleLabel) {
       return;
     }
 
     const syncState = () => {
       const hasParent = Boolean(parentSelect.value);
       requestPublic.disabled = hasParent;
+      publicToggleLabel.classList.toggle("is-disabled", hasParent);
 
       if (hasParent) {
         requestPublic.checked = false;
@@ -287,11 +291,40 @@ export class LinkStackForm extends HTMLElement {
   }
 
   #getFallbackMetadata(url) {
-    const urlObj = new URL(url);
     return {
-      pageTitle: urlObj.hostname.replace("www.", ""),
+      pageTitle: url,
       metaDescription: "",
     };
+  }
+
+  async #fetchMetadata(url) {
+    const isDev = window.location.hostname === "localhost";
+    const baseUrl = isDev ? "http://localhost:8888" : window.location.origin;
+    const endpoint = `${baseUrl}/.netlify/functions/get-bookmark-data`;
+    const controller = new AbortController();
+    const timeoutId = window.setTimeout(() => {
+      controller.abort();
+    }, LinkStackForm.#metadataTimeoutMs);
+
+    try {
+      const response = await fetch(`${endpoint}?url=${encodeURIComponent(url)}`, {
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        return null;
+      }
+
+      return this.#parseMetadataResponse(await response.json(), url);
+    } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") {
+        return null;
+      }
+
+      return null;
+    } finally {
+      window.clearTimeout(timeoutId);
+    }
   }
 
   #parseMetadataResponse(input, url) {
@@ -427,12 +460,9 @@ export class LinkStackForm extends HTMLElement {
           return;
         }
 
-        const isDev = window.location.hostname === "localhost";
-        const baseUrl = isDev ? "http://localhost:8888" : window.location.origin;
-        const endpoint = `${baseUrl}/.netlify/functions/get-bookmark-data`;
-        const response = await fetch(`${endpoint}?url=${encodeURIComponent(url)}`);
+        const metadata = await this.#fetchMetadata(url);
 
-        if (!response.ok) {
+        if (!metadata) {
           await this.#createWithMetadata({
             url,
             notes,
@@ -444,7 +474,7 @@ export class LinkStackForm extends HTMLElement {
           bookmarkForm.reset();
           this.#setupPublicToggle();
           this.#showToast(
-            FORM_UI_MESSAGES.metadataUnavailable,
+            FORM_UI_MESSAGES.bookmarkAddedWithoutMetadata,
             "warning",
           );
           this.#dispatchCreated();
@@ -452,7 +482,6 @@ export class LinkStackForm extends HTMLElement {
           return;
         }
 
-        const metadata = this.#parseMetadataResponse(await response.json(), url);
         await this.#createWithMetadata({
           url,
           notes,

--- a/src/linkstack-public-reviews.js
+++ b/src/linkstack-public-reviews.js
@@ -24,38 +24,43 @@ const reviewCardTemplate = document.createElement("template");
 reviewCardTemplate.innerHTML = `
   <li class="bookmark-entry review-card">
     <div class="bookmark-info">
+      <p class="bookmark-domain review-domain"></p>
       <a class="bookmark-link" target="_blank" rel="noopener noreferrer">
         <h3 class="bookmark-title"></h3>
       </a>
       <p class="bookmark-description"></p>
       <div class="bookmark-tags"></div>
-      <div class="form-field">
-        <label class="review-reason-label">Rejection reason</label>
-        <select class="review-reason"></select>
-      </div>
-      <div class="form-field">
-        <label class="review-note-label">Reviewer note (optional)</label>
-        <input
-          type="text"
-          class="review-note"
-          placeholder="Add context for the submitter"
-        />
+      <div class="review-controls">
+        <div class="form-field">
+          <label class="review-reason-label">Rejection reason</label>
+          <select class="review-reason"></select>
+        </div>
+        <div class="form-field">
+          <label class="review-note-label">Reviewer note (optional)</label>
+          <input
+            type="text"
+            class="review-note"
+            placeholder="Add context for the submitter"
+          />
+        </div>
       </div>
       <div class="bookmark-actions">
-        <button
-          type="button"
-          class="button solid"
-          data-review-action="approve"
-        >
-          Approve
-        </button>
-        <button
-          type="button"
-          class="button solid critical"
-          data-review-action="reject"
-        >
-          Reject
-        </button>
+        <div class="bookmark-actions-primary review-actions-primary">
+          <button
+            type="button"
+            class="button solid"
+            data-review-action="approve"
+          >
+            Approve
+          </button>
+          <button
+            type="button"
+            class="button solid critical"
+            data-review-action="reject"
+          >
+            Reject
+          </button>
+        </div>
       </div>
     </div>
   </li>
@@ -243,6 +248,7 @@ export class LinkStackPublicReviews extends HTMLElement {
       /** @type {DocumentFragment} */ (reviewCardTemplate.content.cloneNode(true));
     const item = fragment.firstElementChild;
     const link = fragment.querySelector(".bookmark-link");
+    const domain = fragment.querySelector(".review-domain");
     const title = fragment.querySelector(".bookmark-title");
     const description = fragment.querySelector(".bookmark-description");
     const tagsContainer = fragment.querySelector(".bookmark-tags");
@@ -256,6 +262,7 @@ export class LinkStackPublicReviews extends HTMLElement {
     if (
       !(item instanceof HTMLLIElement) ||
       !(link instanceof HTMLAnchorElement) ||
+      !(domain instanceof HTMLElement) ||
       !(title instanceof HTMLElement) ||
       !(description instanceof HTMLElement) ||
       !(tagsContainer instanceof HTMLElement) ||
@@ -274,6 +281,7 @@ export class LinkStackPublicReviews extends HTMLElement {
     const noteInputId = `review-note-${listingId}`;
 
     link.href = review.url;
+    domain.textContent = new URL(review.url).hostname.replace(/^www\./u, "");
     title.textContent = review.page_title;
     description.textContent = review.meta_description || "";
     reasonLabel.htmlFor = reasonSelectId;

--- a/src/services/bookmarks.service.js
+++ b/src/services/bookmarks.service.js
@@ -101,6 +101,21 @@ export class BookmarksService {
     return user;
   }
 
+  async #isAdmin(userId) {
+    const { data, error } = await this.#supabase
+      .from("user_roles")
+      .select("role")
+      .eq("user_id", userId)
+      .eq("role", "admin")
+      .maybeSingle();
+
+    if (error) {
+      throw error;
+    }
+
+    return Boolean(data);
+  }
+
   /**
    * @template T
    * @param {{ success: true, output: T } | { success: false, issues?: Array<{ message?: string }> }} result
@@ -791,6 +806,7 @@ export class BookmarksService {
   async requestPublicShare(bookmarkId) {
     const user = await this.#requireUser();
     const bookmark = await this.getById(bookmarkId);
+    const isAdmin = await this.#isAdmin(user.id);
 
     if (bookmark.parent_id) {
       throw new Error("Only top-level bookmarks can be submitted publicly");
@@ -802,18 +818,19 @@ export class BookmarksService {
     }
 
     const existingListing = await this.#findPublicListing(bookmark.resource_id);
+    const now = new Date().toISOString();
     const payload = {
       resource_id: bookmark.resource_id,
       submitted_by_user_id: user.id,
       submitted_by_bookmark_id: bookmark.id,
-      status: PUBLIC_SHARE_STATUS.PENDING,
+      status: isAdmin ? PUBLIC_SHARE_STATUS.APPROVED : PUBLIC_SHARE_STATUS.PENDING,
       page_title: bookmark.page_title,
       meta_description: bookmark.meta_description,
       tags: bookmark.tags || [],
       rejection_code: null,
       rejection_reason: null,
-      reviewed_at: null,
-      reviewed_by: null,
+      reviewed_at: isAdmin ? now : null,
+      reviewed_by: isAdmin ? user.id : null,
     };
 
     let listing;

--- a/tests/unit/bookmarks.service.test.js
+++ b/tests/unit/bookmarks.service.test.js
@@ -162,8 +162,10 @@ describe("BookmarksService", () => {
   let service;
   let store;
   let mockSupabase;
+  let currentUser;
 
   beforeEach(() => {
+    currentUser = { id: "user-2", email: "person@example.com" };
     store = {
       resources: [
         {
@@ -216,7 +218,7 @@ describe("BookmarksService", () => {
     mockSupabase = {
       auth: {
         getUser: async () => ({
-          data: { user: { id: "user-2", email: "person@example.com" } },
+          data: { user: currentUser },
           error: null,
         }),
       },
@@ -351,6 +353,39 @@ describe("BookmarksService", () => {
 
     expect(listing.status).toBe(PUBLIC_SHARE_STATUS.PENDING);
     expect(store.public_listings).toHaveLength(2);
+  });
+
+  it("auto-approves public listings submitted by admins", async () => {
+    currentUser = { id: "user-admin", email: "admin@example.com" };
+    store.resources.push({
+      id: "resource-2",
+      normalized_url: "https://admin.example.com/post",
+      canonical_url: "https://admin.example.com/post",
+      page_title: "Admin article",
+      meta_description: "",
+      created_at: "2026-03-07T07:00:00Z",
+      updated_at: "2026-03-07T07:00:00Z",
+    });
+    store.bookmarks.push({
+      id: "bookmark-2",
+      user_id: "user-admin",
+      resource_id: "resource-2",
+      parent_id: null,
+      title_override: null,
+      description_override: null,
+      notes: "",
+      tags: ["news"],
+      is_read: false,
+      read_at: null,
+      created_at: "2026-03-07T07:10:00Z",
+      updated_at: "2026-03-07T07:10:00Z",
+    });
+
+    const listing = await service.requestPublicShare("bookmark-2");
+
+    expect(listing.status).toBe(PUBLIC_SHARE_STATUS.APPROVED);
+    expect(listing.reviewed_by).toBe("user-admin");
+    expect(listing.reviewed_at).toBeTruthy();
   });
 
   it("reviews a pending public listing", async () => {

--- a/tests/unit/get-bookmark-data.test.js
+++ b/tests/unit/get-bookmark-data.test.js
@@ -62,4 +62,46 @@ describe("get-bookmark-data function", () => {
       metaDescription: "Example description",
     });
   });
+
+  it("returns 502 when the upstream site responds with a non-ok status", async () => {
+    const fetchMock = /** @type {ReturnType<typeof vi.fn>} */ (fetch);
+    fetchMock.mockResolvedValue(new Response("nope", { status: 403, statusText: "Forbidden" }));
+
+    const request = new Request(
+      "http://localhost/.netlify/functions/get-bookmark-data?url=https://example.com/article",
+      {
+        headers: {
+          origin: "http://localhost:8888",
+        },
+      },
+    );
+
+    const response = await handler(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(body.error).toBe(
+      "Failed to fetch metadata from the target site: 403 Forbidden",
+    );
+  });
+
+  it("returns 504 when the upstream fetch times out", async () => {
+    const fetchMock = /** @type {ReturnType<typeof vi.fn>} */ (fetch);
+    fetchMock.mockRejectedValue(new DOMException("The operation was aborted.", "AbortError"));
+
+    const request = new Request(
+      "http://localhost/.netlify/functions/get-bookmark-data?url=https://example.com/article",
+      {
+        headers: {
+          origin: "http://localhost:8888",
+        },
+      },
+    );
+
+    const response = await handler(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(504);
+    expect(body.error).toBe("Timed out while fetching metadata from the target site.");
+  });
 });

--- a/tests/unit/linkstack-public-reviews.test.js
+++ b/tests/unit/linkstack-public-reviews.test.js
@@ -65,6 +65,7 @@ describe("linkstack-public-reviews", () => {
       "1 bookmark waiting for review.",
     );
     expect(document.querySelectorAll(".review-card")).toHaveLength(1);
+    expect(document.querySelector(".review-domain")?.textContent).toBe("example.com");
     expect(document.querySelector(".bookmark-title")?.textContent).toBe("Example article");
     expect(document.querySelectorAll(".bookmark-tags .tag")).toHaveLength(2);
   });


### PR DESCRIPTION
## Summary
- make metadata failures explicit and improve fallback handling in the add-bookmark flow
- auto-approve admin public submissions and improve moderation card layout
- add better diagnostics and status handling to the metadata Netlify function

## Testing
- npm test -- --run tests/unit/bookmarks.service.test.js tests/unit/linkstack-public-reviews.test.js tests/unit/get-bookmark-data.test.js
- npm run lint:js
- npm run lint:css
- npm run typecheck
- npm run build