### PR TITLE
Clean up bookmark deletion and admin success messaging

### DIFF
--- a/src/constants/ui-strings.js
+++ b/src/constants/ui-strings.js
@@ -46,6 +46,7 @@ export const FORM_UI_MESSAGES = Object.freeze({
   duplicateUrl: "This URL has already been bookmarked. Please enter a different URL.",
   bookmarkAdded: "Bookmark added successfully!",
   bookmarkAddedWithReview: "Bookmark added and submitted for public review.",
+  bookmarkAddedAndPublished: "Bookmark added and published publicly.",
   bookmarkAddedWithoutMetadata:
     "Bookmark saved without fetched title or description. You can edit it later.",
   addBookmarkFailed: "Failed to add bookmark. Please try again.",

--- a/src/linkstack-form-supabase.js
+++ b/src/linkstack-form-supabase.js
@@ -288,6 +288,16 @@ export class LinkStackForm extends HTMLElement {
     });
   }
 
+  #getSuccessMessage(createdBookmark, requestPublic) {
+    if (!requestPublic) {
+      return FORM_UI_MESSAGES.bookmarkAdded;
+    }
+
+    return createdBookmark?.public_share_status === "approved"
+      ? FORM_UI_MESSAGES.bookmarkAddedAndPublished
+      : FORM_UI_MESSAGES.bookmarkAddedWithReview;
+  }
+
   #getFallbackMetadata(url) {
     return {
       pageTitle: url,
@@ -468,7 +478,7 @@ export class LinkStackForm extends HTMLElement {
           return;
         }
 
-        await this.#createWithMetadata({
+        const createdBookmark = await this.#createWithMetadata({
           url,
           notes,
           parentId,
@@ -479,9 +489,7 @@ export class LinkStackForm extends HTMLElement {
         bookmarkForm.reset();
         this.#setupPublicToggle();
         this.#showToast(
-          requestPublic
-            ? FORM_UI_MESSAGES.bookmarkAddedWithReview
-            : FORM_UI_MESSAGES.bookmarkAdded,
+          this.#getSuccessMessage(createdBookmark, requestPublic),
           "success",
         );
         this.#dispatchCreated();

--- a/src/services/bookmarks.service.js
+++ b/src/services/bookmarks.service.js
@@ -409,6 +409,34 @@ export class BookmarksService {
       : null;
   }
 
+  async #hasBookmarksForResource(resourceId) {
+    const { data, error } = await this.#supabase
+      .from("bookmarks")
+      .select("id")
+      .eq("resource_id", resourceId)
+      .maybeSingle();
+
+    if (error) {
+      throw error;
+    }
+
+    return Boolean(data);
+  }
+
+  async #hasPublicListingForResource(resourceId) {
+    const { data, error } = await this.#supabase
+      .from("public_listings")
+      .select("id")
+      .eq("resource_id", resourceId)
+      .maybeSingle();
+
+    if (error) {
+      throw error;
+    }
+
+    return Boolean(data);
+  }
+
   async #createResource(bookmark) {
     const normalizedUrl = normalizeUrl(bookmark.url);
     const resourcePayload = {
@@ -768,6 +796,20 @@ export class BookmarksService {
   }
 
   async delete(id) {
+    const bookmark = await this.getById(id);
+    const listing = await this.#findPublicListing(bookmark.resource_id);
+
+    if (listing?.submitted_by_bookmark_id === id) {
+      const { error: listingError } = await this.#supabase
+        .from("public_listings")
+        .delete()
+        .eq("id", listing.id);
+
+      if (listingError) {
+        throw listingError;
+      }
+    }
+
     const { error } = await this.#supabase
       .from("bookmarks")
       .delete()
@@ -775,6 +817,22 @@ export class BookmarksService {
 
     if (error) {
       throw error;
+    }
+
+    const [hasBookmarks, hasPublicListing] = await Promise.all([
+      this.#hasBookmarksForResource(bookmark.resource_id),
+      this.#hasPublicListingForResource(bookmark.resource_id),
+    ]);
+
+    if (!hasBookmarks && !hasPublicListing) {
+      const { error: resourceError } = await this.#supabase
+        .from("resources")
+        .delete()
+        .eq("id", bookmark.resource_id);
+
+      if (resourceError) {
+        throw resourceError;
+      }
     }
   }
 

--- a/tests/unit/bookmarks.service.test.js
+++ b/tests/unit/bookmarks.service.test.js
@@ -416,6 +416,40 @@ describe("BookmarksService", () => {
     expect(reviewed.rejection_code).toBe("out_of_scope");
   });
 
+  it("deletes the public listing and resource when removing the submitted bookmark", async () => {
+    currentUser = { id: "user-1", email: "owner@example.com" };
+
+    await service.delete("bookmark-1");
+
+    expect(store.bookmarks).toHaveLength(0);
+    expect(store.public_listings).toHaveLength(0);
+    expect(store.resources).toHaveLength(0);
+  });
+
+  it("keeps the public listing and resource when deleting a private copy of a public resource", async () => {
+    store.bookmarks.push({
+      id: "bookmark-2",
+      user_id: "user-2",
+      resource_id: "resource-1",
+      parent_id: null,
+      title_override: null,
+      description_override: null,
+      notes: "",
+      tags: [],
+      is_read: false,
+      read_at: null,
+      created_at: "2026-03-06T11:00:00Z",
+      updated_at: "2026-03-06T11:00:00Z",
+    });
+
+    await service.delete("bookmark-2");
+
+    expect(store.bookmarks).toHaveLength(1);
+    expect(store.bookmarks[0].id).toBe("bookmark-1");
+    expect(store.public_listings).toHaveLength(1);
+    expect(store.resources).toHaveLength(1);
+  });
+
   it("requires a rejection reason when rejecting a public listing", async () => {
     await expect(
       service.reviewPublicShare("listing-1", {


### PR DESCRIPTION
## Summary
- show the correct success toast for admin-submitted public bookmarks
- delete related public listings when removing the submitted bookmark
- remove orphaned resources when no bookmarks or public listings remain

## Testing
- npm test -- --run tests/unit/bookmarks.service.test.js
- npm run lint:js
- npm run typecheck
- npm run build