### PR TITLE
Allow bookmark cleanup deletes through RLS

### DIFF
--- a/src/services/bookmarks.service.js
+++ b/src/services/bookmarks.service.js
@@ -437,6 +437,25 @@ export class BookmarksService {
     return Boolean(data);
   }
 
+  async #deleteRowById(table, id, failureMessage) {
+    const { data, error } = await this.#supabase
+      .from(table)
+      .delete()
+      .eq("id", id)
+      .select("id")
+      .maybeSingle();
+
+    if (error) {
+      throw error;
+    }
+
+    if (!data) {
+      throw new Error(failureMessage);
+    }
+
+    return data;
+  }
+
   async #createResource(bookmark) {
     const normalizedUrl = normalizeUrl(bookmark.url);
     const resourcePayload = {
@@ -800,24 +819,18 @@ export class BookmarksService {
     const listing = await this.#findPublicListing(bookmark.resource_id);
 
     if (listing?.submitted_by_bookmark_id === id) {
-      const { error: listingError } = await this.#supabase
-        .from("public_listings")
-        .delete()
-        .eq("id", listing.id);
-
-      if (listingError) {
-        throw listingError;
-      }
+      await this.#deleteRowById(
+        "public_listings",
+        listing.id,
+        "Failed to delete the public listing tied to this bookmark.",
+      );
     }
 
-    const { error } = await this.#supabase
-      .from("bookmarks")
-      .delete()
-      .eq("id", id);
-
-    if (error) {
-      throw error;
-    }
+    await this.#deleteRowById(
+      "bookmarks",
+      id,
+      "Failed to delete this bookmark.",
+    );
 
     const [hasBookmarks, hasPublicListing] = await Promise.all([
       this.#hasBookmarksForResource(bookmark.resource_id),
@@ -825,14 +838,11 @@ export class BookmarksService {
     ]);
 
     if (!hasBookmarks && !hasPublicListing) {
-      const { error: resourceError } = await this.#supabase
-        .from("resources")
-        .delete()
-        .eq("id", bookmark.resource_id);
-
-      if (resourceError) {
-        throw resourceError;
-      }
+      await this.#deleteRowById(
+        "resources",
+        bookmark.resource_id,
+        "Failed to delete the orphaned resource tied to this bookmark.",
+      );
     }
   }
 

--- a/supabase/migrations/20260315_add_delete_policies_for_cleanup.sql
+++ b/supabase/migrations/20260315_add_delete_policies_for_cleanup.sql
@@ -1,0 +1,39 @@
+-- Migration: add delete policies for public listings and orphan resources
+-- Date: 2026-03-15
+-- Description:
+--   Bookmark deletion now cleans up associated public_listings and orphaned
+--   resources. RLS previously allowed SELECT/INSERT/UPDATE on these tables but
+--   did not allow DELETE, which caused silent no-op deletes through PostgREST.
+--
+--   This migration:
+--   - allows owners/admins to delete public listings
+--   - allows admins or any authenticated user to delete resources only once
+--     those resources are orphaned (no bookmarks and no public listing remain)
+
+CREATE POLICY "admins and authenticated users can delete orphan resources"
+  ON public.resources
+  FOR DELETE
+  USING (
+    public.is_admin()
+    OR (
+      auth.uid() IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1
+        FROM public.bookmarks
+        WHERE bookmarks.resource_id = resources.id
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM public.public_listings
+        WHERE public_listings.resource_id = resources.id
+      )
+    )
+  );
+
+CREATE POLICY "owners and admins can delete public listings"
+  ON public.public_listings
+  FOR DELETE
+  USING (
+    public.is_admin()
+    OR submitted_by_user_id = auth.uid()
+  );

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -158,6 +158,26 @@ CREATE POLICY "bookmark owners and admins can update resources"
     )
   );
 
+CREATE POLICY "admins and authenticated users can delete orphan resources"
+  ON public.resources
+  FOR DELETE
+  USING (
+    public.is_admin()
+    OR (
+      auth.uid() IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1
+        FROM public.bookmarks
+        WHERE bookmarks.resource_id = resources.id
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM public.public_listings
+        WHERE public_listings.resource_id = resources.id
+      )
+    )
+  );
+
 CREATE POLICY "approved public listings are public"
   ON public.public_listings
   FOR SELECT
@@ -189,6 +209,14 @@ CREATE POLICY "owners can submit public listings"
 CREATE POLICY "owners and admins can update public listings"
   ON public.public_listings
   FOR UPDATE
+  USING (
+    public.is_admin()
+    OR submitted_by_user_id = auth.uid()
+  );
+
+CREATE POLICY "owners and admins can delete public listings"
+  ON public.public_listings
+  FOR DELETE
   USING (
     public.is_admin()
     OR submitted_by_user_id = auth.uid()

--- a/tests/unit/bookmarks.service.test.js
+++ b/tests/unit/bookmarks.service.test.js
@@ -139,16 +139,19 @@ class MockQueryBuilder {
 
     if (this.operation === "delete") {
       const remaining = [];
-      let deleted = false;
+      const deletedRows = [];
       this.#getTable().forEach((row) => {
         if (this.filters.every((filter) => filter(row))) {
-          deleted = true;
+          deletedRows.push(row);
           return;
         }
         remaining.push(row);
       });
       this.store[this.table] = remaining;
-      return { data: [], error: deleted ? null : new Error("Delete failed") };
+      return {
+        data: deletedRows,
+        error: deletedRows.length ? null : new Error("Delete failed"),
+      };
     }
 
     return {


### PR DESCRIPTION
## Summary
- add DELETE RLS policies for public_listings and orphan resources
- make bookmark cleanup deletes verify that rows were actually removed
- add a migration for existing Supabase projects

## Testing
- npm test -- --run tests/unit/bookmarks.service.test.js
- npm run lint:js
- npm run typecheck
- npm run build

## Deployment note
- apply supabase/migrations/20260315_add_delete_policies_for_cleanup.sql before testing deletion in production