### PR TITLE
Allow non-admins to read newly created resources

### DIFF
--- a/supabase/migrations/20260318_allow_select_on_orphan_resources.sql
+++ b/supabase/migrations/20260318_allow_select_on_orphan_resources.sql
@@ -1,0 +1,47 @@
+-- Migration: allow authenticated users to read orphan resources
+-- Date: 2026-03-18
+-- Description:
+--   Non-admin users can create a new resource, but the create flow currently
+--   performs INSERT ... SELECT to return the new row. Immediately after insert,
+--   the resource has no bookmark and no public listing yet, so the previous
+--   SELECT policy blocked access with a 403.
+--
+--   This migration allows authenticated users to read orphan resources:
+--   resources with no bookmarks and no public listing. That covers the
+--   just-created resource during bookmark creation without opening general
+--   access to private linked resources.
+
+DROP POLICY IF EXISTS "resource owners and public catalog can read resources"
+  ON public.resources;
+
+CREATE POLICY "resource owners and public catalog can read resources"
+  ON public.resources
+  FOR SELECT
+  USING (
+    public.is_admin()
+    OR (
+      auth.uid() IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1
+        FROM public.bookmarks
+        WHERE bookmarks.resource_id = resources.id
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM public.public_listings
+        WHERE public_listings.resource_id = resources.id
+      )
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.bookmarks
+      WHERE bookmarks.resource_id = resources.id
+        AND bookmarks.user_id = auth.uid()
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.public_listings
+      WHERE public_listings.resource_id = resources.id
+        AND public_listings.status = 'approved'
+    )
+  );

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -126,6 +126,19 @@ CREATE POLICY "resource owners and public catalog can read resources"
   FOR SELECT
   USING (
     public.is_admin()
+    OR (
+      auth.uid() IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1
+        FROM public.bookmarks
+        WHERE bookmarks.resource_id = resources.id
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM public.public_listings
+        WHERE public_listings.resource_id = resources.id
+      )
+    )
     OR EXISTS (
       SELECT 1
       FROM public.bookmarks


### PR DESCRIPTION
## Summary
- allow authenticated users to read orphan resources through RLS
- fix non-admin bookmark creation for brand-new URLs when the create flow returns the inserted resource row
- add a migration for existing Supabase projects

## Testing
- npm run lint:js
- npm run typecheck
- npm run build

## Deployment note
- apply supabase/migrations/20260318_allow_select_on_orphan_resources.sql before retesting non-admin bookmark creation in production